### PR TITLE
Enabling optional generation of qa products

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tesp',
       url='https://github.com/OpenDataCubePipelines/tesp',
       description=('A temporary solution to get packaging underway. '
                    'Code will eventually be ported eo-datasets.'),
-      packages=find_packages(),
+      packages=find_packages(exclude=("tests", )),
       install_requires=[
           'click',
           'click_datetime',

--- a/tesp/yaml_merge.py
+++ b/tesp/yaml_merge.py
@@ -48,7 +48,7 @@ def provider_reference_info(granule, wagl_tags):
     return provider_info
 
 
-def merge_metadata(level1_tags, wagl_tags, gqa_tags, granule, image_paths):
+def merge_metadata(level1_tags, wagl_tags, granule, image_paths, **antecedent_tags):
     """
     Combine the metadata from input sources and output
     into a single ARD metadata yaml.
@@ -60,20 +60,9 @@ def merge_metadata(level1_tags, wagl_tags, gqa_tags, granule, image_paths):
              'SENTINEL_2A': 'S2MSIARD',
              'SENTINEL_2B': 'S2MSIARD'}
 
-    source_tags = {level1_tags['product_type']: copy.deepcopy(level1_tags)}
-    provider_info = provider_reference_info(granule, wagl_tags)
-
     # TODO: resolve common software version for fmask and gqa
-    fmask_repo_url = 'https://bitbucket.org/chchrsc/python-fmask'
     software_versions = wagl_tags['software_versions']
 
-    # Add software versions from gqa yaml
-    gqa_versions = gqa_tags.pop('software_versions')
-    for key, value in gqa_versions.items():
-        software_versions[key] = value
-
-    software_versions['fmask'] = {'repo_url': fmask_repo_url,
-                                  'version': fmask.__version__}
     software_versions['tesp'] = {'repo_url': tesp_repo_url,
                                  'version': tesp_version()}
 
@@ -81,14 +70,12 @@ def merge_metadata(level1_tags, wagl_tags, gqa_tags, granule, image_paths):
     # Merge tags from each input and create a UUID
     merged_yaml = {
         'algorithm_information': wagl_tags['algorithm_information'],
-        'software_versions': software_versions,
         'system_information': wagl_tags['system_information'],
         'id': str(uuid.uuid4()),
         'processing_level': 'Level-2',
         'product_type': ptype[wagl_tags['source_datasets']['platform_id']],
         'platform': {'code': wagl_tags['source_datasets']['platform_id']},
         'instrument': {'name': wagl_tags['source_datasets']['sensor_id']},
-        'gqa': gqa_tags,
         'format': {'name': 'GeoTIFF'},
         'tile_id': granule,
         'extent': level1_tags['extent'],
@@ -96,11 +83,27 @@ def merge_metadata(level1_tags, wagl_tags, gqa_tags, granule, image_paths):
         'image': {'bands': image_paths},
         'lineage': {
             'ancillary': wagl_tags['ancillary'],
-            'source_datasets': source_tags
+            'source_datasets': {
+                level1_tags['product_type']: copy.deepcopy(level1_tags)
+            }
         },
     }
 
+    # Handles GQA and Fmask metadata currently
+    # Configured to handle gqa and fmask antecedent tasks
+    for task_name, task_md in antecedent_tags.items():
+        if 'software_versions' in task_md:
+            for key, value in task_md.pop('software_versions').items():
+                software_versions[key] = value  # This fails on key conflicts
+
+        # Check for valid metadata after merging the software versions
+        if task_md:
+            merged_yaml[task_name] = task_md
+
+    provider_info = provider_reference_info(granule, wagl_tags)
     if provider_info:
         merged_yaml['provider'] = provider_info
+
+    merged_yaml['software_versions'] = software_versions
 
     return merged_yaml

--- a/tesp/yaml_merge.py
+++ b/tesp/yaml_merge.py
@@ -17,7 +17,6 @@ import re
 
 import click
 import yaml
-import fmask
 from tesp.version import get_version as tesp_version
 from tesp.version import REPO_URL as tesp_repo_url
 
@@ -67,7 +66,6 @@ def merge_metadata(level1_tags, wagl_tags, granule, image_paths, **antecedent_ta
                                  'version': tesp_version()}
 
     # TODO: extend yaml document to include fmask and gqa yamls
-    # Merge tags from each input and create a UUID
     merged_yaml = {
         'algorithm_information': wagl_tags['algorithm_information'],
         'system_information': wagl_tags['system_information'],


### PR DESCRIPTION
Here is proposed code for optionally disabling gqa/fmask

Benefits
* Removes hardcoding of fmask and gqa fields in ymal merge function

Limitations
* Assumes wagl has run
* (Still) not a plugin architecture
* Hardcodes a gqa value when gqa didn't run
* Metadata for eugl-fmask integration is created in tesp

Not sure when it will be cleanest to merge functionality into collection upgrade branch too