### PR TITLE
Framework for sensitivity analysis

### DIFF
--- a/tesp/sensitivity.py
+++ b/tesp/sensitivity.py
@@ -8,82 +8,74 @@ import luigi
 import h5py
 import numpy
 import rasterio
+import yaml
 
-from wagl.acquisition import acquisitions
+from wagl.acquisition import preliminary_acquisitions_data
 from wagl.singlefile_workflow import DataStandardisation
 from wagl.constants import ArdProducts, GroupName, DatasetName
 from tesp.package import PATTERN2, ARD
 from tesp.workflow import RunFmask
 
 
-def aerosol_summary(l2_path, fmask_path, granule, aerosol):
+class ExperimentList(luigi.WrapperTask):
+    """
+    A helper task that issues `Experiment` tasks for each Level-1
+    dataset listed in the `level1_list` parameter and each experiment specified.
+    """
+    level1_list = luigi.Parameter()
+    workdir = luigi.Parameter()
+    pkgdir = luigi.Parameter()
+    experiment_list_yaml = luigi.Parameter()
+    tags = luigi.ListParameter(default=[])
+    cleanup = luigi.BoolParameter()
+    acq_parser_hint = luigi.OptionalParameter(default='')
 
-    with rasterio.open(fmask_path) as mask_file:
-        fmask = mask_file.read(1)
+    def requires(self):
+        with open(self.level1_list) as src:
+            level1_list = [level1.strip() for level1 in src.readlines()]
 
-    valid_pixels = fmask == 1
+        with open(self.experiment_list_yaml) as fl:
+            experiments = yaml.load(fl)
 
-    def mask_invalid(img):
-        return numpy.where(img != -999, img, numpy.nan)
+        for tag, settings in experiments.items():
+            if not self.tags or tag in self.tags:
+                for level1 in level1_list:
+                    for granule in preliminary_acquisitions_data(level1, self.acq_parser_hint):
+                        work_root = pjoin(self.workdir, '{}.{}'.format(basename(level1), tag))
+                        work_dir = pjoin(work_root, granule['id'])
 
-    yield ['product', 'date', 'granule', 'band', 'aerosol', 'mean', 'std', 'valid_pixels']
+                        yield Experiment(level1, work_dir, granule['id'], self.pkgdir, tag, settings, self.cleanup)
 
-    with h5py.File(l2_path) as h5:
+# NOTE we probably need one more level here that creates the temporal mean image
 
-        def get(*keys):
-            return h5['/'.join([granule, *keys])]
-
-        def band_dataset(product, band):
-            for res_group in ['RES-GROUP-2', 'RES-GROUP-1', 'RES-GROUP-0']:
-                try:
-                    return get(res_group, GroupName.STANDARD_GROUP.value,
-                               DatasetName.REFLECTANCE_FMT.value.format(product=product, band_name=band))
-                except KeyError:
-                    pass
-
-            raise KeyError(f'could not find {product} {band} in {granule}')
-
-        assert abs(aerosol - get(GroupName.ANCILLARY_GROUP.value, DatasetName.AEROSOL.value)[...]) < 0.00001
-
-        date = get(GroupName.ATMOSPHERIC_INPUTS_GRP.value).attrs['acquisition-datetime'][:len('2000-01-01')]
-
-        def process_band(product, band):
-            try:
-                ds = band_dataset(product, band)
-                band_name = ds.attrs['alias']
-                data = numpy.where(valid_pixels, mask_invalid(ds[:]), numpy.nan)
-
-                yield [product, date, granule, band_name,
-                       aerosol, numpy.nanmean(data), numpy.nanstd(data), numpy.sum(valid_pixels)]
-            except KeyError:
-                pass
-
-        for product in [p.value for p in ArdProducts]:
-            for band in [f'BAND-{b}' for b in range(1, 8)]:
-                yield from process_band(product, band)
-
-
-class Aerosol(luigi.Task):
-    """ Sensitivity analysis for aerosol. """
+class Experiment(luigi.Task):
+    """ Sensitivity analysis experiment. """
     level1 = luigi.Parameter()
     workdir = luigi.Parameter()
     granule = luigi.OptionalParameter(default='')
     pkgdir = luigi.Parameter()
-    aerosol = luigi.FloatParameter(default=0.05)
+    tag = luigi.Parameter()
+    settings = luigi.DictParameter()
     cleanup = luigi.BoolParameter()
 
     def _output_folder(self):
         granule = re.sub(PATTERN2, ARD, self.granule)
-        return pjoin(self.pkgdir, granule)
+        return pjoin(self.pkgdir, self.tag, granule)
 
     def _output_filename(self):
-        return pjoin(self._output_folder(), f'summary_{self.aerosol}.csv')
+        return pjoin(self._output_folder(), f'summary.csv')
 
     def requires(self):
+        settings = {}
+        for key, value in self.settings.items():
+            if key == 'normalized_solar_zenith':
+                settings[key] = value
+            else:
+                settings[key] = {'user': value}
+
         tasks = {
-            'wagl': DataStandardisation(self.level1, self.workdir, self.granule,
-                                        aerosol={'user': self.aerosol}),
-            'fmask': RunFmask(self.level1, self.granule, self.workdir)
+            'wagl': DataStandardisation(self.level1, self.workdir, self.granule, **settings),
+            'fmask': RunFmask(self.level1, self.granule, self.workdir, upstream_settings=settings)
         }
 
         return tasks
@@ -101,37 +93,51 @@ class Aerosol(luigi.Task):
         with open(self._output_filename(), 'w+') as csv_file:
             writer = csv.writer(csv_file)
 
-            for entry in aerosol_summary(inputs['wagl'].path, inputs['fmask'].path,
-                                         self.granule, self.aerosol):
+            for entry in experiment_summary(inputs['wagl'].path, inputs['fmask'].path,
+                                            self.granule, self.tag, self.settings):
                 writer.writerow(entry)
 
-        if self.cleanup:
-            shutil.rmtree(self.workdir)
 
+def experiment_summary(l2_path, fmask_path, granule, tag, settings):
 
-class Aerosols(luigi.WrapperTask):
-    """
-    A helper Task that issues Aerosol Tasks for each Level-1
-    dataset listed in the `level1_list` parameter.
-    """
-    level1_list = luigi.Parameter()
-    workdir = luigi.Parameter()
-    pkgdir = luigi.Parameter()
-    aerosols = luigi.ListParameter()
-    cleanup = luigi.BoolParameter()
-    acq_parser_hint = luigi.OptionalParameter(default='')
+    with rasterio.open(fmask_path) as mask_file:
+        fmask = mask_file.read(1)
 
-    def requires(self):
-        with open(self.level1_list) as src:
-            level1_list = [level1.strip() for level1 in src.readlines()]
+    valid_pixels = fmask == 1
 
-        for level1 in level1_list:
-            container = acquisitions(level1, self.acq_parser_hint)
+    def mask_invalid(img):
+        return numpy.where(img != -999, img, numpy.nan)
 
-            for aerosol in self.aerosols:
-                work_root = pjoin(self.workdir, '{}.AERO{}'.format(basename(level1), str(aerosol)))
+    yield ['product', 'date', 'granule', 'band', 'experiment', 'mean', 'std', 'valid_pixels']
 
-                for granule in container.granules:
-                    work_dir = container.get_root(work_root, granule=granule)
+    with h5py.File(l2_path) as h5:
 
-                    yield Aerosol(level1, work_dir, granule, self.pkgdir, float(aerosol), self.cleanup)
+        def get(*keys):
+            return h5['/'.join([granule, *keys])]
+
+        def band_dataset(product, band):
+            for res_group in ['RES-GROUP-2', 'RES-GROUP-1', 'RES-GROUP-0']:
+                try:
+                    return get(res_group, GroupName.STANDARD_GROUP.value,
+                               DatasetName.REFLECTANCE_FMT.value.format(product=product, band_name=band))
+                except KeyError:
+                    pass
+
+            raise KeyError(f'could not find {product} {band} in {granule}')
+
+        date = get(GroupName.ATMOSPHERIC_INPUTS_GRP.value).attrs['acquisition-datetime'][:len('2000-01-01')]
+
+        def process_band(product, band):
+            try:
+                ds = band_dataset(product, band)
+                band_name = ds.attrs['alias']
+                data = numpy.where(valid_pixels, mask_invalid(ds[:]), numpy.nan)
+
+                yield [product, date, granule, band_name,
+                       tag, numpy.nanmean(data), numpy.nanstd(data), numpy.sum(valid_pixels)]
+            except KeyError:
+                pass
+
+        for product in [p.value for p in ArdProducts]:
+            for band in [f'BAND-{b}' for b in range(1, 8)]:
+                yield from process_band(product, band)

--- a/tesp/workflow.py
+++ b/tesp/workflow.py
@@ -73,13 +73,14 @@ class RunFmask(luigi.Task):
     level1 = luigi.Parameter()
     granule = luigi.Parameter()
     workdir = luigi.Parameter()
+    upstream_settings = luigi.DictParameter(default={})
     acq_parser_hint = luigi.OptionalParameter(default='')
 
     def requires(self):
         # for the time being have fmask require wagl,
         # no point in running fmask if wagl fails...
         # return WorkDir(self.level1, dirname(self.workdir))
-        return DataStandardisation(self.level1, self.workdir, self.granule)
+        return DataStandardisation(self.level1, self.workdir, self.granule, **self.upstream_settings)
 
     def output(self):
         out_fname = pjoin(self.workdir, '{}.fmask.img'.format(self.granule))


### PR DESCRIPTION
This PR introduces a general framework to design sensitivity analysis experiments.

- `luigi` configuration can now specify a `experiment_list_yaml` that contains the experiment list
- the experiment list is really a `dict` mapping experiment names to settings
- the settings are `DataStandardisation` settings to be overridden for the purpose of the experiment