### PR TITLE
Batch summary

### DIFF
--- a/bin/ard_pbs
+++ b/bin/ard_pbs
@@ -109,7 +109,7 @@ def _submit_multiple(scattered, env, batch_logdir, batch_outdir, pkgdir,
 
 def _submit_summary(indir, outdir, batch_id, pbs_resources, env, job_ids, test):
     """Summarise the jobs submitted within the batchjob."""
-    jobids = ":".join([j.split('.')[0] for j in job_ids)
+    jobids = ":".join([j.split('.')[0] for j in job_ids])
     pbs = SUMMARY_TEMPLATE.format(pbs_resources=pbs_resources, env=env,
                                   indir=indir, outdir=outdir, jobids=jobids)
 

--- a/bin/ard_pbs
+++ b/bin/ard_pbs
@@ -35,7 +35,7 @@ luigi --module tesp.workflow ARDP --level1-list {scene_list} --workdir {outdir} 
 """)
 
 SUMMARY_TEMPLATE = ("""{pbs_resources}
-#PBS depend=afterany:{jobids}
+#PBS -W depend=afterany:{jobids}
 
 source {env}
 batch_summary --indir {indir} --outdir {outdir}

--- a/bin/ard_pbs
+++ b/bin/ard_pbs
@@ -109,7 +109,7 @@ def _submit_multiple(scattered, env, batch_logdir, batch_outdir, pkgdir,
 
 def _submit_summary(indir, outdir, batch_id, pbs_resources, env, job_ids, test):
     """Summarise the jobs submitted within the batchjob."""
-    jobids = ":".join(job_ids)
+    jobids = ":".join([j.split('.')[0] for j in job_ids)
     pbs = SUMMARY_TEMPLATE.format(pbs_resources=pbs_resources, env=env,
                                   indir=indir, outdir=outdir, jobids=jobids)
 

--- a/bin/ard_pbs
+++ b/bin/ard_pbs
@@ -34,11 +34,19 @@ source {env}
 luigi --module tesp.workflow ARDP --level1-list {scene_list} --workdir {outdir} --pkgdir {pkgdir} --workers {workers} --parallel-scheduling
 """)
 
+SUMMARY_TEMPLATE = ("""{pbs_resources}
+#PBS depend=afterany:{jobids}
+
+source {env}
+batch_summary --indir {indir} --outdir {outdir}
+""")
+
 
 FMT1 = 'batchid-{batchid}'
 FMT2 = 'jobid-{jobid}'
 FMT3 = 'level1-scenes-{jobid}.txt'
 FMT4 = 'jobid-{jobid}.bash'
+FMT5 = 'batch-{batchid}.bash'
 DAEMON_FMT = 'luigid --background --logdir {}'
 
 
@@ -97,6 +105,37 @@ def _submit_multiple(scattered, env, batch_logdir, batch_outdir, pkgdir,
 
     # return a list of the nci job ids
     return nci_job_ids
+
+
+def _submit_summary(indir, outdir, batch_id, pbs_resources, env, job_ids, test):
+    """Summarise the jobs submitted within the batchjob."""
+    jobids = ":".join(job_ids)
+    pbs = SUMMARY_TEMPLATE.format(pbs_resources=pbs_resources, env=env,
+                                  indir=indir, outdir=outdir, jobids=jobids)
+
+    out_fname = pjoin(indir, FMT5.format(batchid=batch_id))
+    with open(out_fname, 'w') as src:
+        src.write(pbs)
+
+    if test:
+        click.echo("Mocking... Submitting Job: {} ...Mocking".format(batch_id))
+        click.echo("qsub {}".format(out_fname))
+
+    os.chdir(dirname(out_fname))
+    click.echo("Submitting Job: {}".format(batch_id))
+    try:
+        raw_output = subprocess.check_output(['qsub', out_fname])
+    except subprocess.CalledProcessError as exc:
+        logging.error('qsub failed with exit code %s', str(exc.returncode))
+        logging.error(exc.output)
+        raise
+
+    if hasattr(raw_output, 'decode'):
+        matches = re.match('^(?P<nci_job_id>\d{7,}.r-man2)$', raw_output.decode('utf-8'))
+        if matches:
+            job_id = matches.groupdict()['nci_job_id']
+
+    return job_id
 
 
 @click.command()
@@ -158,6 +197,16 @@ def main(level1_list, workdir, logdir, pkgdir, env, workers, nodes, memory,
     nci_job_ids = _submit_multiple(scattered, env, batch_logdir, batch_outdir,
                                    pkgdir, workers, pbs_resources, test)
 
+    # job resources for batch summary
+    pbs_resources = PBS_RESOURCES.format(project=project, queue='express',
+                                         walltime="00:10:00", memory=6,
+                                         ncpus=1, jobfs=2,
+                                         email=('#PBS -M ' + email) if email else "")
+
+    job_id = _submit_summary(batch_logdir, batch_logdir, batchid,
+                             pbs_resources, env, nci_job_ids, test)
+
+    nci_job_ids.append(job_id)
     job_details = {
         'ardpbs_batch_id': batchid,
         'nci_job_ids': nci_job_ids

--- a/bin/batch_summary
+++ b/bin/batch_summary
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+"""
+Summarise all the jobs submitted within a given batch.
+"""
+
+from pathlib import Path
+import click
+from luigi_db_utils import retrieve_status
+
+
+@click.command()
+@click.option("--indir", type=click.Path(file_okay=False, readable=True),
+              help="The input directory of the batchjob.")
+@click.option("--outdir", type=click.Path(file_okay=False, writable=True),
+              help=("The output directory to contain the done, failed, and "
+                    "pending lists."))
+def main(indir, outdir):
+    """
+    """
+    # status lists
+    reprocess = []
+    done = []
+    fail = []
+
+    outdir = Path(outdir)
+    files = Path(indir).rglob('luigi-task-hist.db')
+
+    for fname in files:
+        done_df, fail_df, pending_df = retrieve_status(str(fname), 'Package')
+        reprocess.extend(pending_df.value.tolist())
+        done.extend(done_df.value.tolist())
+        fail.extend(fail_df.value.tolist())
+
+    out_fname = outdir.joinpath('level-1-pending.txt')
+    with open(out_fname, 'w') as src:
+        src.writelines(['{}\n'.format(fname) for fname in reprocess])
+
+    out_fname = outdir.joinpath('level-1-done.txt')
+    with open(out_fname, 'w') as src:
+        src.writelines(['{}\n'.format(fname) for fname in done])
+
+    out_fname = outdir.joinpath('level-1-failed.txt')
+    with open(out_fname, 'w') as src:
+        src.writelines(['{}\n'.format(fname) for fname in fail])
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/batch_summary
+++ b/bin/batch_summary
@@ -6,7 +6,7 @@ Summarise all the jobs submitted within a given batch.
 
 from pathlib import Path
 import click
-from luigi_db_utils import retrieve_status
+from tesp.luigi_db_utils import retrieve_status
 
 
 @click.command()

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(name='tesp',
                'bin/ard_pbs',
                'bin/search_s2',
                'bin/s2-nci-processing',
-               'batch_summary'],
+               'bin/batch_summary'],
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(name='tesp',
       scripts=['bin/s2package',
                'bin/ard_pbs',
                'bin/search_s2',
-               'bin/s2-nci-processing'],
+               'bin/s2-nci-processing',
+               'batch_summary'],
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ setup(name='tesp',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       url='https://github.com/OpenDataCubePipelines/tesp',
-      description=('A temporary solution to get packaging underway. '
-                   'Code will eventually be ported eo-datasets.'),
+      description='Data Pipeline construction.',
       packages=find_packages(exclude=("tests", )),
       install_requires=[
           'click',
@@ -41,7 +40,7 @@ setup(name='tesp',
       ),
       dependency_links=[
           'git+https://github.com/GeoscienceAustralia/eo-datasets.git@develop#egg=eodatasets',
-          'git+https://github.com/GeoscienceAustralia/wagl@master#egg=wagl',
+          'git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl',
           'git+https://github.com/OpenDataCubePipelines/eugl.git@master#egg=eugl',
       ],
 

--- a/tesp/luigi_db_utils.py
+++ b/tesp/luigi_db_utils.py
@@ -9,10 +9,8 @@ Eg:
 db_connection = sqlite:///luigi-task-hist.db
 """
 
-from pathlib import Path
 import sqlite3
 import pandas
-import click
 
 
 def read_task_db(fname):
@@ -31,13 +29,10 @@ def read_task_db(fname):
     return tasks, events, params
 
 
-def retrieve_status(fname, task_name=None):
+def retrieve_status(fname, task_name):
     """
     Retrieve the task status given by `task_name` for each L1 dataset.
     """
-    if task_name is None:
-        raise ValueError('Parameter "task_name" cannot be None')
-
     tasks, events, params = read_task_db(fname)
 
     task = tasks[tasks.name == task_name]

--- a/tesp/luigi_db_utils.py
+++ b/tesp/luigi_db_utils.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+Utilities for accessing and querying the task history database that
+the luigi scheduler can output.
+Requires the luigi config to have the *task_history* defined.
+Eg:
+[task_history]
+db_connection = sqlite:///luigi-task-hist.db
+"""
+
+from pathlib import Path
+import sqlite3
+import pandas
+import click
+
+
+def read_task_db(fname):
+    """
+    Read a task history database written by luigi.
+    """
+    connection = sqlite3.connect(fname)
+    # cursor = connection.cursor()
+    # query = "SELECT name FROM sqlite_master WHERE type='table';"
+    # tables = cursor.execute(query).fetchall()
+
+    tasks = pandas.read_sql_query("SELECT * from tasks", connection)
+    events = pandas.read_sql_query("SELECT * from task_events", connection)
+    params = pandas.read_sql_query("SELECT * from task_parameters", connection)
+
+    return tasks, events, params
+
+
+def retrieve_status(fname, task_name=None):
+    """
+    Retrieve the task status given by `task_name` for each L1 dataset.
+    """
+    if task_name is None:
+        raise ValueError('Parameter "task_name" cannot be None')
+
+    tasks, events, params = read_task_db(fname)
+
+    task = tasks[tasks.name == task_name]
+    l1_datasets = params[params.name == 'level1']
+
+    # event status for the DataStandardisation Task
+    status = task.merge(events, how='left', left_on='id', right_on='task_id',
+                        suffixes=['_{}'.format(task_name), '_events'])
+
+    # final status for each DataStandardisation Task
+    final_status = status.drop_duplicates('id_{}'.format(task_name),
+                                          keep='last')
+
+    # get the DONE, FAILED & PENDING Tasks
+    # (if the task status is PENDING:
+    # then the compute job could've timed out
+    # or
+    # an upstream dependency failed for some reason
+    done = final_status[final_status.event_name == 'DONE']
+    fail = final_status[final_status.event_name == 'FAILED']
+    pending = final_status[final_status.event_name == 'PENDING']
+
+    l1_done = done.merge(l1_datasets, how='left', right_on='task_id',
+                         left_on='id_{}'.format(task_name))
+    l1_fail = fail.merge(l1_datasets, how='left', right_on='task_id',
+                         left_on='id_{}'.format(task_name))
+    l1_pending = pending.merge(l1_datasets, how='left', right_on='task_id',
+                               left_on='id_{}'.format(task_name))
+
+    return l1_done, l1_fail, l1_pending


### PR DESCRIPTION
A minor improvement that summarises a batch job and produces 3 text files containing level-1 scenes that have:

* task-done
* task-failed
* task-pending

This is a quick and easy start point for building a monitoring system.

I'm only checking the 'Package' task, as that is the final task for each individual scene.
As such, *fail* means packaging failed, *done* means packaging succeeded (and so did everything else up the pipeline), and *pending* means either something failed up the pipeline, or compute job ran out of walltime, or something happened to the job and was killed or prematurely stopped for some reason.