### PR TITLE
Provide greater clarity at a granule level

### DIFF
--- a/bin/batch_summary
+++ b/bin/batch_summary
@@ -6,15 +6,24 @@ Summarise all the jobs submitted within a given batch.
 
 from pathlib import Path
 import click
+import structlog
+from structlog.processors import JSONRenderer
 from tesp.luigi_db_utils import retrieve_status
+
+
+COMMON_PROCESSORS = [
+    structlog.stdlib.add_log_level,
+    structlog.processors.TimeStamper(fmt="ISO"),
+    JSONRenderer(sort_keys=True),
+]
 
 
 @click.command()
 @click.option("--indir", type=click.Path(file_okay=False, readable=True),
               help="The input directory of the batchjob.")
 @click.option("--outdir", type=click.Path(file_okay=False, writable=True),
-              help=("The output directory to contain the done, failed, and "
-                    "pending lists."))
+              help=("The output directory to contain the done, failed, pending "
+                    "and running lists."))
 def main(indir, outdir):
     """
     """
@@ -27,12 +36,56 @@ def main(indir, outdir):
     outdir = Path(outdir)
     files = Path(indir).rglob('luigi-task-hist.db')
 
-    for fname in files:
-        done_df, fail_df, pending_df, running_df = retrieve_status(str(fname), 'Package')
-        reprocess.extend(pending_df.value.tolist())
-        done.extend(done_df.value.tolist())
-        fail.extend(fail_df.value.tolist())
-        running.extend(running_df.value.tolist())
+    msg = "package task state at end of batchjob"
+    structlog.configure(processors=COMMON_PROCESSORS)
+    state_log = structlog.get_logger("task-final-state")
+
+    final_state_out_fname = outdir.joinpath("{}-level1-final-state.jsonl".format(indir.name))
+    with open(final_state_out_fname, "w") as fobj:
+        structlog.configure(logger_factory=structlog.PrintLoggerFactory(fobj))
+
+        for fname in files:
+            done_df, fail_df, pending_df, running_df = retrieve_status(str(fname), 'Package')
+            reprocess.extend(pending_df.value_level1.tolist())
+            done.extend(done_df.value_level1.tolist())
+            fail.extend(fail_df.value_level1.tolist())
+            running.extend(running_df.value_level1.tolist())
+
+            # log granules that have state DONE
+            for i, row in done_df.iterrows():
+                state_log.info(
+                    msg,
+                    final_state="done",
+                    level1=row.value_level1,
+                    granule=row.value_granule
+                )
+
+            # log granules that have state PENDING
+            for i, row in pending_df.iterrows():
+                state_log.info(
+                    msg,
+                    final_state="pending",
+                    level1=row.value_level1,
+                    granule=row.value_granule
+                )
+
+            # log granules that have state FAILED
+            for i, row in fail_df.iterrows():
+                state_log.info(
+                    msg,
+                    final_state="failed",
+                    level1=row.value_level1,
+                    granule=row.value_granule
+                )
+
+            # log granules that have state RUNNING
+            for i, row in running_df.iterrows():
+                state_log.info(
+                    msg,
+                    final_state="running",
+                    level1=row.value_level1,
+                    granule=row.value_granule
+                )
 
     out_fname_fmt = "level-1-final_state-{}.txt"
     out_fname = outdir.joinpath(out_fname_fmt.format("pending"))

--- a/tesp/luigi_db_utils.py
+++ b/tesp/luigi_db_utils.py
@@ -37,6 +37,9 @@ def retrieve_status(fname, task_name):
 
     task = tasks[tasks.name == task_name]
     l1_datasets = params[params.name == 'level1']
+    granules = params[params.name == 'granule']
+    l1_granules = l1_datasets.merge(granules, suffixes=('_level1', '_granule'),
+                                    on='task_id')
 
     # event status for the DataStandardisation Task
     status = task.merge(events, how='left', left_on='id', right_on='task_id',
@@ -56,11 +59,13 @@ def retrieve_status(fname, task_name):
     pending = final_status[final_status.event_name == 'PENDING']
     running = final_status[final_status.event_name == 'RUNNING']
 
-    l1_done = done.merge(l1_datasets, how='left', right_on='task_id',
+    l1_done = done.merge(l1_granules, how='left', right_on='task_id',
                          left_on='id_{}'.format(task_name))
-    l1_fail = fail.merge(l1_datasets, how='left', right_on='task_id',
+    l1_fail = fail.merge(l1_granules, how='left', right_on='task_id',
                          left_on='id_{}'.format(task_name))
-    l1_pending = pending.merge(l1_datasets, how='left', right_on='task_id',
+    l1_pending = pending.merge(l1_granules, how='left', right_on='task_id',
+                               left_on='id_{}'.format(task_name))
+    l1_running = running.merge(l1_granules, how='left', right_on='task_id',
                                left_on='id_{}'.format(task_name))
     l1_running = running.merge(l1_datasets, how='left', right_on='task_id',
                                left_on='id_{}'.format(task_name))


### PR DESCRIPTION
The reason for this addition is to provide greater clarity at a granule level on what is done, failed, pending, running.
The background on granule is that a level1 file such as a USGS ".tar" or ESA ".zip", they could contain 1 or more granules.  The Landsat data is a single granule (may change in future), whereas the ESA data is a mixture.

Without this level of granularity, a Sentinel-2 file can be reported as pending but it might be only 1 of multiple granules contained within the zip file.

In the end, this is a small future-proofing for when we do a Sentinel-2 archive reprocess.