### PR TITLE
Fixed issue regarding confliction between metadata packages.

### DIFF
--- a/tesp/__init__.py
+++ b/tesp/__init__.py
@@ -1,10 +1,10 @@
 try:
-    from importlib import metadata
+    from importlib import metadata as _md
 except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
-    import importlib_metadata as metadata
+    import importlib_metadata as _md
 
 try:
-    __version__ = metadata.version(__name__)
-except metadata.PackageNotFoundError:
+    __version__ = _md.version(__name__)
+except _md.PackageNotFoundError:
     __version__ = "Not Installed"


### PR DESCRIPTION
A very minor fix to resolve a library conflict when loading metadata from importlib (which occurs in `tesp.__init__`), and metadata from tesp.