### PR TITLE
Fix CI build (config conflicts)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-
-[flake8]
-
-# Shorter is better, but would involve changing too much code.
-max_line_length = 120
-
-doctests = True
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.10.0
     hooks:
     -   id: black
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: ''  # pick a git hash / tag to point to
+    rev: '3.9.2'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = E203,W503,E231
-max-line-length = 90
+max-line-length = 120
 
 [pycodestyle]
 ignore = E203


### PR DESCRIPTION
This fixes the current github-actions build. Is needed for #98 (to fix NCI storage)

There were two competing flake8 configs.

I've also bumped pre-commit as its install failed.... but it looks like it doesn't get run on this repository, as the repository formatting doesn't folllow any of it.